### PR TITLE
feat: add ollama nix package

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -35,6 +35,7 @@
       svelte-language-server
       nodePackages.aws-cdk
       nodejs
+      ollama
       nodePackages."@angular/cli"
       awscli2
       vscode-langservers-extracted


### PR DESCRIPTION
Adds the `ollama` package to the home-manager configuration. This will make the ollama CLI available in the environment.